### PR TITLE
Fix a bug for input:`""`.

### DIFF
--- a/jl_fuzz_test.go
+++ b/jl_fuzz_test.go
@@ -1,0 +1,17 @@
+package jl
+
+import (
+	"testing"
+)
+
+func FuzzJlProcess(f *testing.F) {
+	f.Fuzz(func(t *testing.T, prettify bool, showErr bool, splitTab bool, data []byte) {
+		options := &Options{
+			Prettify: prettify,
+			ShowErr:  showErr,
+			SplitTab: splitTab,
+		}
+
+		Process(options, data)
+	})
+}

--- a/jl_test.go
+++ b/jl_test.go
@@ -13,6 +13,7 @@ func TestProcess(t *testing.T) {
 	}{
 		// not JSON
 		{in: "", expect: ""},
+		{in: `""`, expect: `""`},
 		{in: "not json", expect: "not json"},
 		{in: "{]", expect: "{]"},
 

--- a/untangle.go
+++ b/untangle.go
@@ -145,6 +145,10 @@ func untangleStringValue(o *Options, pks *[]PathKey, flatters *[]Flatter, v stri
 }
 
 func wouldBeJSON(src *[]byte) *json.RawMessage {
+	if len(*src) == 0 {
+		return nil
+	}
+
 	if firstChar := (*src)[0]; firstChar != charObject && firstChar != charArray {
 		return nil
 	}


### PR DESCRIPTION
Add fuzzing test. (Thanks @peterhellberg)

Pass:
```
$ gotest -fuzz Fuzz -fuzztime=60s
fuzz: elapsed: 0s, gathering baseline coverage: 0/231 completed
fuzz: elapsed: 0s, gathering baseline coverage: 231/231 completed, now fuzzing with 2 workers
fuzz: elapsed: 3s, execs: 72454 (24145/sec), new interesting: 12 (total: 243)
fuzz: elapsed: 6s, execs: 116391 (14647/sec), new interesting: 17 (total: 248)
fuzz: elapsed: 9s, execs: 173015 (18873/sec), new interesting: 24 (total: 255)
fuzz: elapsed: 12s, execs: 230349 (19113/sec), new interesting: 32 (total: 263)
fuzz: elapsed: 15s, execs: 280947 (16865/sec), new interesting: 49 (total: 280)
fuzz: elapsed: 18s, execs: 355678 (24911/sec), new interesting: 50 (total: 281)
fuzz: elapsed: 21s, execs: 426003 (23443/sec), new interesting: 54 (total: 285)
fuzz: elapsed: 24s, execs: 470887 (14959/sec), new interesting: 55 (total: 286)
fuzz: elapsed: 27s, execs: 515288 (14800/sec), new interesting: 57 (total: 288)
fuzz: elapsed: 30s, execs: 556406 (13707/sec), new interesting: 58 (total: 289)
fuzz: elapsed: 33s, execs: 600756 (14733/sec), new interesting: 65 (total: 296)
fuzz: elapsed: 36s, execs: 638970 (12781/sec), new interesting: 69 (total: 300)
fuzz: elapsed: 39s, execs: 674306 (11776/sec), new interesting: 73 (total: 304)
fuzz: elapsed: 42s, execs: 713156 (12953/sec), new interesting: 87 (total: 318)
fuzz: elapsed: 45s, execs: 749812 (12218/sec), new interesting: 88 (total: 319)
fuzz: elapsed: 48s, execs: 768371 (6186/sec), new interesting: 89 (total: 320)
fuzz: elapsed: 51s, execs: 810020 (13886/sec), new interesting: 90 (total: 321)
fuzz: elapsed: 54s, execs: 834350 (8109/sec), new interesting: 91 (total: 322)
fuzz: elapsed: 57s, execs: 834350 (0/sec), new interesting: 91 (total: 322)
fuzz: elapsed: 1m0s, execs: 834350 (0/sec), new interesting: 91 (total: 322)
fuzz: elapsed: 1m1s, execs: 834350 (0/sec), new interesting: 91 (total: 322)
PASS
ok      github.com/bayashi/go-jl        61.012s
```